### PR TITLE
Enable control demo instead of in-place library demo (throws security error in UI5Lab-browser)

### DIFF
--- a/test/openui5/camera/Camera.html
+++ b/test/openui5/camera/Camera.html
@@ -7,7 +7,7 @@
 
 	<title>Testpage - openui5.camera.Camera</title>
 
-	<base href="../../">
+	<base href="../../../">
 	<!--[if lte IE 9]><script>
 	    (function() {
 		var baseTag = document.getElementsByTagName('base')[0];

--- a/test/openui5/camera/index.json
+++ b/test/openui5/camera/index.json
@@ -17,10 +17,9 @@
                 "description": "Take pictures in your UI5 app. Pure javascript implementation.",
                 "samples": [
                     {
-                        "id": "camera",
-                        "name": "Simple demo",
-                        "description": "Click the camera preview to push png's into the model",
-                        "url": "https://jumpifzero.github.io/openui5-camera/test/demo/"
+                        "id": "Camera",
+                        "name": "Simple Camera Control demo",
+                        "description": "See the library demo for a full-featured example"
                     }
                 ]
             }


### PR DESCRIPTION
Hello, we made some adjustments to your library to preview the control sample properly in the UI5Lab browser.
Please republish after merging the pull so that we can consume the new version via npm.